### PR TITLE
 Fix parameter naming 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Configures the time synchronization application `chrony` as a client or master t
 
 ### client
 
-Configures the node to use the `chrony` application to keep the node's clock synced. If there is a node using the `chrony::master` recipe, the client will attempt to sync with it. If there is not an available master, the attribute list `['chrony'][:servers]` is used (defaults are `[0-3].debian.pool.ntp.org`). If there is a master node, the `['chrony'][:allowed]` and `['chrony']['initslewstep']` will be set to allow for syncing with the master.
+Configures the node to use the `chrony` application to keep the node's clock synced. If there is a node using the `chrony::master` recipe, the client will attempt to sync with it. If there is not an available master, the attribute list `['chrony'][:servers]` is used (defaults are `[0-3].debian.pool.ntp.org`). If there is a master node, the `['chrony'][:allowed]` and `['chrony']['initstepslew']` will be set to allow for syncing with the master.
 
 ### default
 
@@ -26,7 +26,7 @@ The default recipe passes through to the client recipe.
 
 ### master
 
-The node will use the `chrony` application to provide time to nodes using the `chrony::client` recipe. The master sets its own time against the attribute list `['chrony'][:servers]` (defaults are `[0-3].debian.pool.ntp.org`). Access to this master is restricted by the `['chrony'][:allowed]` attribute set in the recipe (default is to the x.y.* subnet). If the `['chrony'][:servers]` are empty, the master will set its `['chrony']['initslewstep']` to the first 3 client nodes returned by search (it will set it to the first 3 `['chrony'][:servers]` otherwise).
+The node will use the `chrony` application to provide time to nodes using the `chrony::client` recipe. The master sets its own time against the attribute list `['chrony'][:servers]` (defaults are `[0-3].debian.pool.ntp.org`). Access to this master is restricted by the `['chrony'][:allowed]` attribute set in the recipe (default is to the x.y.* subnet). If the `['chrony'][:servers]` are empty, the master will set its `['chrony']['initstepslew']` to the first 3 client nodes returned by search (it will set it to the first 3 `['chrony'][:servers]` otherwise).
 
 ## Usage
 
@@ -35,7 +35,7 @@ Nodes using the `chrony::client` recipe will attempt to sync time with nodes usi
 The current configurations are supported:
 1) Clients with direct NTP server access
 2) A master with direct NTP server access with clients pointing to it
-3) Isolated master and clients, using the `initslewstep` to keep the master and clients synced. Manually setting the server's time may be required.
+3) Isolated master and clients, using the `initstepslew` to keep the master and clients synced. Manually setting the server's time may be required.
 
 ## License and Author
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,10 +25,13 @@ default['chrony']['servers'] = {
   '3.debian.pool.ntp.org' => 'offline minpoll 8',
 }
 
+# if this server turns out to be a NTP server and is picked by others nodes
+# running the client recipe, this attribute will be used as the NTP options
+# for this server
 default['chrony']['server_options'] = 'offline minpoll 8'
 
 # set in the client & master recipes
 default['chrony']['allow'] = ['allow']
 
 # set in the client & master recipes
-default['chrony']['initslewstep'] = ''
+default['chrony']['initstepslew'] = ''

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -36,7 +36,7 @@ if !masters.empty?
     node.default['chrony']['servers'][master['ipaddress']] = master['chrony']['server_options']
     node.default['chrony']['allow'].push "allow #{master['ipaddress']}"
     # only use 1 server to sync initslewstep
-    node.default['chrony']['initslewstep'] = "initslewstep 20 #{master['ipaddress']}"
+    node.default['chrony']['initstepslew'] = "initstepslew 20 #{master['ipaddress']}"
   end
 else
   Chef::Log.info('No chrony master(s) found, using node[:chrony][:servers] attribute.')

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -29,20 +29,20 @@ end
 # set the allowed hosts to the class B
 # node['chrony'][:allow] = ["allow #{ip[0]}.#{ip[1]}"]
 
-# if there are NTP servers, use the first 3 for the initslew
+# if there are NTP servers, use the first 3 for the initstepslew
 if !node['chrony']['servers'].empty?
-  node.default['chrony']['initslewstep'] = 'initslewstep 10'
+  node.default['chrony']['initstepslew'] = 'initstepslew 10'
   keys = node['chrony']['servers'].keys.sort
   count = 3
   count = keys.length if keys.length < count
-  count.times { |x| node.default['chrony']['initslewstep'] += " #{keys[x]}" }
+  count.times { |x| node.default['chrony']['initstepslew'] += " #{keys[x]}" }
 else # else use first 3 clients
   clients = search(:node, 'recipes:chrony\:\:client').sort || []
   unless clients.empty?
-    node.default['chrony']['initslewstep'] = 'initslewstep 10'
+    node.default['chrony']['initstepslew'] = 'initstepslew 10'
     count = 3
     count = clients.length if clients.length < count
-    count.times { |x| node['chrony']['initslewstep'] += " #{clients[x].ipaddress}" }
+    count.times { |x| node.default['chrony']['initstepslew'] += " #{clients[x].ipaddress}" }
   end
 end
 

--- a/templates/chrony.conf.erb
+++ b/templates/chrony.conf.erb
@@ -96,5 +96,5 @@ logchange 0.5
 # change it if necessary.
 rtconutc
 
-# initslewstep added for isolated networks
-<%= node['chrony']['initslewstep'] %>
+# initstepslew added for isolated networks
+<%= node['chrony']['initstepslew'] %>


### PR DESCRIPTION
According to the documentation https://chrony.tuxfamily.org/doc/3.4/chrony.conf.html#initstepslew the
correct name of the parameter is : `initstepslew`.