### PR TITLE
conditionally search for masters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the chrony cookbook.
 
 ## Unreleased
 
+- Conditionally search for masters
+
 ## 1.0.0 - *2021-01-21*
 
 - Sous Chefs Adoption

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This cookbook is maintained by the Sous Chefs. The Sous Chefs are a community of
 
 ### client
 
-Configures the node to use the `chrony` application to keep the node's clock synced. If there is a node using the `chrony::master` recipe, the client will attempt to sync with it. If there is not an available master, the attribute list `['chrony'][:servers]` is used (defaults are `[0-3].debian.pool.ntp.org`). If there is a master node, the `['chrony'][:allowed]` will be set to allow for syncing with the master.
+Configures the node to use the `chrony` application to keep the node's clock synced. If there is a node using the `chrony::master` recipe, the client will attempt to sync with it, unless disabled via `['chrony']['search_masters']`. If there is not an available master, the attribute list `['chrony'][:servers]` is used (defaults are `[0-3].debian.pool.ntp.org`). If there is a master node, the `['chrony'][:allowed]` will be set to allow for syncing with the master.
 
 ### default
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,6 +27,10 @@ default['chrony']['servers'] = {
 
 default['chrony']['server_options'] = 'offline minpoll 8'
 
+# Use servers including recipe chrony::master registered in Chef server
+# to populate our servers list.
+default['chrony']['search_masters'] = true
+
 # set in the client & master recipes
 # for better security, clients that do not need to serve ntp requests to peers or other clients
 # should not have the `allow` directive in chrony.conf

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -30,7 +30,8 @@ end
 
 # search for the chrony master(s), if found populate the template accordingly
 # typical deployment will only have 1 master, but still allow for multiple
-masters = search(:node, 'recipes:chrony\:\:master') || []
+masters = search(:node, 'recipes:chrony\:\:master') if node['chrony']['search_masters']
+masters ||= []
 if masters.empty?
   Chef::Log.info("No chrony master(s) found, using node['chrony']['servers'] attribute.")
 else


### PR DESCRIPTION
# Description

Chef search may not be desired due to a large Chef
environment or simply because of user defined servers.

Keep seach by default, but allow to skip it, so search
is not run, and user defined servers are used.

## Check List

- [x] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable.
