### PR TITLE
Fix issue with client providing allow list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is used to list changes made in each version of the chrony cookbook.
 ## Unreleased
 
 - Remove delivery folder
+- Fix issue with setting allow list in client recipe
 
 ## 1.2.0 - *2021-11-22*
 

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -42,7 +42,8 @@ template 'chrony.conf' do
   owner 'root'
   group 'root'
   mode '0644'
-  variables driftfile: node['chrony']['driftfile'],
+  variables allow: node['chrony']['allow'],
+            driftfile: node['chrony']['driftfile'],
             log_dir: node['chrony']['log_dir'],
             servers: node['chrony']['servers']
   notifies :restart, 'service[chrony]', :delayed

--- a/templates/chrony_client.conf.erb
+++ b/templates/chrony_client.conf.erb
@@ -21,6 +21,15 @@ rtcsync
 # Specify directory for log files.
 logdir <%= @log_dir %>
 
+# The allow directive is used to designate a particular subnet from which clients
+# are allowed to access chrony. As a client option this can be used for accessing the the
+# NTP interface to query status information.
+<% if @allow %>
+<%    @allow.each do |allowed| %>
+allow <%= allowed %>
+<%    end %>
+<% end %>
+
 # Extra configuration
 <% node['chrony']['extra_config'].each do |conf| -%>
 <%= conf %>


### PR DESCRIPTION
# Description

This fix ensures that the allow list is provided to the chrony config file. This is required when the `default['chrony']['allow']` list is set either automatically by master discovery or directly via node attributes.

## Issues Resolved

Resolves issue where setting the `allow` attribute in chef is not reflected in the configuration file when calling the client recipe

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing. -- N/A no new functionality
- [ ] New functionality has been documented in the README if applicable. - Not required as this fixes an existing bug.

