### PR TITLE
Removed default['chrony']['servers'] content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the chrony cookbook.
 
 ## Unreleased
 
+- Removed default['chrony']['servers'] content - to allow it to be overridden by role/environment.
+
 ## 1.2.3 - *2023-03-02*
 
 - Remove delivery workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ This file is used to list changes made in each version of the chrony cookbook.
 
 - Minor updates to the kitchen files and metadata.rb source fix - [@tas50](https://github.com/tas50)
 - Use platform_family so we also support RHEL-like platforms like Oracle Linux - [@gsreynolds](https://github.com/gsreynolds)
-- Cookstyle Bot Auto Corrections with Cookstyle 6.18.8 - [@cookstyle](https://github.com/cookstyle)
+- Cookstyle Bot Auto Corrections with Cookstyle 6.18.8 - [@cookstyle](https://github.com/chef/cookstyle)
 
 ## 0.3.0 (2020-02-10
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,7 +26,7 @@
 #   'ntp1.example.com' => 'iburst',
 #   'ntp2.example.com' => 'iburst'
 # }
-default['chrony']['servers'] = { }
+default['chrony']['servers'] = {}
 
 default['chrony']['server_options'] = 'offline minpoll 8'
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,10 +20,13 @@
 # limitations under the License.
 #
 
-# hash of default servers in the chrony.conf from Ubuntu
-default['chrony']['servers'] = {
- 'pool.ntp.org' => 'iburst',
-}
+# servers to add in chrony.conf - empty so that role/environment can define a fresh set.
+#  - Is a hash with key as the server, and the value options. e.g.
+# default['chrony']['servers'] = {
+#   'ntp1.example.com' => 'iburst',
+#   'ntp2.example.com' => 'iburst'
+# }
+default['chrony']['servers'] = { }
 
 default['chrony']['server_options'] = 'offline minpoll 8'
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,10 +21,14 @@
 #
 
 # servers to add in chrony.conf - empty so that role/environment can define a fresh set.
-#  - Is a hash with key as the server, and the value options. e.g.
-# default['chrony']['servers'] = {
-#   'ntp1.example.com' => 'iburst',
-#   'ntp2.example.com' => 'iburst'
+#  - Is a hash with the key as the server, and the value as the server options. e.g. role JSON:
+# "default_attributes" : {
+#   "chrony": {
+#     "servers": {
+#       "ntp1.example.com" => "iburst",
+#       "ntp2.example.com" => "iburst"
+#     }
+#   }
 # }
 default['chrony']['servers'] = {}
 

--- a/spec/unit/recipes/client_spec.rb
+++ b/spec/unit/recipes/client_spec.rb
@@ -23,6 +23,7 @@
 require 'spec_helper'
 
 describe 'chrony::client' do
+  default_attributes['chrony']['servers'] = { 'pool.ntp.org' => 'iburst' } 
   context 'on Ubuntu 18.04' do
     cached(:chef_run) do
       ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '18.04').converge(described_recipe)

--- a/spec/unit/recipes/client_spec.rb
+++ b/spec/unit/recipes/client_spec.rb
@@ -23,7 +23,7 @@
 require 'spec_helper'
 
 describe 'chrony::client' do
-  default_attributes['chrony']['servers'] = { 'pool.ntp.org' => 'iburst' } 
+  default_attributes['chrony']['servers'] = { 'pool.ntp.org' => 'iburst' }
   context 'on Ubuntu 18.04' do
     cached(:chef_run) do
       ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '18.04').converge(described_recipe)

--- a/spec/unit/recipes/client_spec.rb
+++ b/spec/unit/recipes/client_spec.rb
@@ -23,7 +23,7 @@
 require 'spec_helper'
 
 describe 'chrony::client' do
-  default_attributes['chrony']['servers'] = { 'pool.ntp.org' => 'iburst' }
+  override_attributes['chrony']['servers'] = { 'pool.ntp.org' => 'iburst' }
   context 'on Ubuntu 18.04' do
     cached(:chef_run) do
       ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '18.04').converge(described_recipe)

--- a/spec/unit/recipes/master_spec.rb
+++ b/spec/unit/recipes/master_spec.rb
@@ -24,6 +24,7 @@
 require 'spec_helper'
 
 describe 'chrony::master' do
+  default_attributes['chrony']['servers'] = { 'pool.ntp.org' => 'iburst' }
   context 'on Ubuntu 18.04' do
     cached(:chef_run) do
       ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '18.04').converge(described_recipe)

--- a/spec/unit/recipes/master_spec.rb
+++ b/spec/unit/recipes/master_spec.rb
@@ -24,7 +24,7 @@
 require 'spec_helper'
 
 describe 'chrony::master' do
-  default_attributes['chrony']['servers'] = { 'pool.ntp.org' => 'iburst' }
+  override_attributes['chrony']['servers'] = { 'pool.ntp.org' => 'iburst' }
   context 'on Ubuntu 18.04' do
     cached(:chef_run) do
       ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '18.04').converge(described_recipe)

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -1,3 +1,6 @@
 # Workaround issue running chronyd in docker related to:
 # https://access.redhat.com/solutions/4410831
 directory '/var/run/chrony' if platform_family?('rhel')
+
+default['chrony']['servers'] = { 'pool.ntp.org' => 'iburst' }
+

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -2,4 +2,4 @@
 # https://access.redhat.com/solutions/4410831
 directory '/var/run/chrony' if platform_family?('rhel')
 
-node.default['chrony']['servers'] = { 'pool.ntp.org' => 'iburst' }
+node.override['chrony']['servers'] = { 'pool.ntp.org' => 'iburst' }

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -2,5 +2,4 @@
 # https://access.redhat.com/solutions/4410831
 directory '/var/run/chrony' if platform_family?('rhel')
 
-default['chrony']['servers'] = { 'pool.ntp.org' => 'iburst' }
-
+node.default['chrony']['servers'] = { 'pool.ntp.org' => 'iburst' }


### PR DESCRIPTION
# Description

Allows Chrony servers to be defined in role/environment

## Issues Resolved

https://github.com/sous-chefs/chrony/issues/34

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
