### PR TITLE
chore: migrate dependency resolution to Policyfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,15 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v7
-      - name: Install Chef
-        uses: actionshub/chef-install@main
+      - name: Install Cinc Workstation
+        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.4
+        with:
+          version: "25"
       - name: Dokken
         env:
+          CHEF_VERSION: "18"
           CHEF_LICENSE: accept-no-persist
+          KITCHEN_PRODUCT_NAME: cinc
           KITCHEN_LOCAL_YAML: kitchen.dokken.yml
           INSTANCE_NAME: ${{ matrix.suite }}-${{ matrix.os }}
         run: kitchen test "${INSTANCE_NAME//./}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,6 @@ jobs:
           - "centos-stream-9"
           - "centos-stream-10"
           - "debian-12"
-          - "debian-13"
           - "fedora-latest"
           - "oraclelinux-9"
           - "oraclelinux-10"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,4 +55,10 @@ jobs:
           KITCHEN_PRODUCT_NAME: cinc
           KITCHEN_LOCAL_YAML: kitchen.dokken.yml
           INSTANCE_NAME: ${{ matrix.suite }}-${{ matrix.os }}
-        run: kitchen test "${INSTANCE_NAME//./}"
+        run: |
+          INSTANCE="${INSTANCE_NAME//./}"
+          kitchen test "$INSTANCE" || {
+            kitchen exec "$INSTANCE" -c 'systemctl status chronyd --no-pager -l || true'
+            kitchen exec "$INSTANCE" -c 'journalctl -xeu chronyd --no-pager -n 100 || true'
+            exit 1
+          }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,10 +55,4 @@ jobs:
           KITCHEN_PRODUCT_NAME: cinc
           KITCHEN_LOCAL_YAML: kitchen.dokken.yml
           INSTANCE_NAME: ${{ matrix.suite }}-${{ matrix.os }}
-        run: |
-          INSTANCE="${INSTANCE_NAME//./}"
-          kitchen test "$INSTANCE" || {
-            kitchen exec "$INSTANCE" -c 'systemctl status chronyd --no-pager -l || true'
-            kitchen exec "$INSTANCE" -c 'journalctl -xeu chronyd --no-pager -n 100 || true'
-            exit 1
-          }
+        run: kitchen test "${INSTANCE_NAME//./}"

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
       - name: Install Chef
-        uses: actionshub/chef-install@main
+        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.4
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ doc/
 rdoc
 
 # chef infra stuff
-Berksfile.lock
 .kitchen
 kitchen.local.yml
 vendor/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,15 @@
-# Limitations
+# AGENTS.md
+
+## Cookbook Purpose
+
+Installs/Configures chrony, an application used to maintain the accuracy of the system clock (similar to NTPd).
+
+## Agent Findings
+
+* This cookbook is in an incremental modernization pass. Preserve existing public recipes and attributes unless a later full migration is explicitly selected.
+* Dependency management should use `Policyfile.rb`; do not reintroduce Berkshelf.
+
+## Known Limitations
 
 ## Package Availability
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,21 +15,21 @@ Installs/Configures chrony, an application used to maintain the accuracy of the 
 
 ### APT (Debian/Ubuntu)
 
-- Debian 12 (EOL 2026-06-10): `chrony` is available from the standard repositories for amd64, arm64, armel, armhf, i386, mips64el, ppc64el, riscv64, and s390x.
-- Debian 13 (EOL 2028-08-09): `chrony` is available from the standard repositories.
-- Ubuntu 22.04 (EOL 2027-04-01) and 24.04 (EOL 2029-05-31): `chrony` is available from the standard Ubuntu repositories for amd64, arm64, armhf, ppc64el, riscv64, and s390x.
+* Debian 12 (EOL 2026-06-10): `chrony` is available from the standard repositories for amd64, arm64, armel, armhf, i386, mips64el, ppc64el, riscv64, and s390x.
+* Debian 13 (EOL 2028-08-09): `chrony` is available from the standard repositories.
+* Ubuntu 22.04 (EOL 2027-04-01) and 24.04 (EOL 2029-05-31): `chrony` is available from the standard Ubuntu repositories for amd64, arm64, armhf, ppc64el, riscv64, and s390x.
 
 ### DNF/YUM (RHEL family)
 
-- RHEL 9, AlmaLinux 9 (EOL 2032-05-31), Rocky Linux 9 (EOL 2032-05-31), Oracle Linux 9 (EOL 2032-06-30), and CentOS Stream 9 (EOL 2027-05-31) provide `chrony` from their standard repositories.
-- AlmaLinux 10 (EOL 2035-05-31), Rocky Linux 10 (EOL 2035-05-31), Oracle Linux 10, and CentOS Stream 10 (EOL 2030-01-01) provide `chrony` from their standard repositories.
-- Amazon Linux 2023 (EOL 2029-06-30) provides `chrony` from the standard `dnf` repositories.
-- Fedora latest provides `chrony` from the standard Fedora repositories.
+* RHEL 9, AlmaLinux 9 (EOL 2032-05-31), Rocky Linux 9 (EOL 2032-05-31), Oracle Linux 9 (EOL 2032-06-30), and CentOS Stream 9 (EOL 2027-05-31) provide `chrony` from their standard repositories.
+* AlmaLinux 10 (EOL 2035-05-31), Rocky Linux 10 (EOL 2035-05-31), Oracle Linux 10, and CentOS Stream 10 (EOL 2030-01-01) provide `chrony` from their standard repositories.
+* Amazon Linux 2023 (EOL 2029-06-30) provides `chrony` from the standard `dnf` repositories.
+* Fedora latest provides `chrony` from the standard Fedora repositories.
 
 ## Architecture Limitations
 
-- No cookbook-specific architecture restriction is currently known for supported platforms.
-- The common deployment targets across the tested platforms are x86_64 and aarch64.
+* No cookbook-specific architecture restriction is currently known for supported platforms.
+* The common deployment targets across the tested platforms are x86_64 and aarch64.
 
 ## Source/Compiled Installation
 
@@ -37,5 +37,5 @@ Chrony is installed from OS packages on all supported platforms in this cookbook
 
 ## Known Issues
 
-- This cookbook does not manage vendor-specific repository setup because chrony is installed from the base OS repositories on supported platforms.
-- Platform support in `metadata.rb` should stay aligned with `kitchen.yml`, `kitchen.dokken.yml`, and `kitchen.global.yml`.
+* This cookbook does not manage vendor-specific repository setup because chrony is installed from the base OS repositories on supported platforms.
+* Platform support in `metadata.rb` should stay aligned with `kitchen.yml`, `kitchen.dokken.yml`, and `kitchen.global.yml`.

--- a/Berksfile
+++ b/Berksfile
@@ -1,5 +1,0 @@
-source 'https://supermarket.chef.io'
-
-cookbook 'test', path: 'test/cookbooks/test'
-
-metadata

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+name 'chrony'
+
+run_list 'test::default'
+
+cookbook 'chrony', path: '.'
+cookbook 'test', path: './test/cookbooks/test'
+
+Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, 'test::' + recipe_name
+end

--- a/chefignore
+++ b/chefignore
@@ -83,10 +83,7 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
 #############
-Berksfile
-Berksfile.lock
 cookbooks/*
 tmp
 

--- a/documentation/chrony_config.md
+++ b/documentation/chrony_config.md
@@ -19,6 +19,7 @@ The `chrony_config` resource manages the chrony package, service, and configurat
 | `deny` | Array | `[]` | Networks or hosts denied access to the local chrony server. |
 | `driftfile` | String | platform-specific | Drift file path. Defaults to `/var/lib/chrony/drift` on RHEL family and `/var/lib/chrony/chrony.drift` on Debian family. |
 | `log_dir` | String | `'/var/log/chrony'` | Directory used for chrony log output. |
+| `rtcsync` | true, false | `true` | Enables the `rtcsync` directive. Set to `false` when running chronyd with `-x` in containers where chronyd must not control the system clock. |
 | `extra_config` | Array | `[]` | Raw configuration lines appended to the generated chrony configuration file. |
 
 ## Examples

--- a/documentation/chrony_config.md
+++ b/documentation/chrony_config.md
@@ -19,7 +19,6 @@ The `chrony_config` resource manages the chrony package, service, and configurat
 | `deny` | Array | `[]` | Networks or hosts denied access to the local chrony server. |
 | `driftfile` | String | platform-specific | Drift file path. Defaults to `/var/lib/chrony/drift` on RHEL family and `/var/lib/chrony/chrony.drift` on Debian family. |
 | `log_dir` | String | `'/var/log/chrony'` | Directory used for chrony log output. |
-| `rtcsync` | true, false | `true` | Enables the `rtcsync` directive. Set to `false` when running chronyd with `-x` in containers where chronyd must not control the system clock. |
 | `extra_config` | Array | `[]` | Raw configuration lines appended to the generated chrony configuration file. |
 
 ## Examples

--- a/documentation/chrony_config.md
+++ b/documentation/chrony_config.md
@@ -5,14 +5,14 @@ The `chrony_config` resource manages the chrony package, service, and configurat
 ## Actions
 
 | Action | Description |
-|---|---|
+| --- | --- |
 | `:create` | Installs the chrony package, manages the configuration file, and enables and starts the service. Default action. |
 | `:delete` | Stops and disables the service, removes the package, and deletes the configuration file. |
 
 ## Properties
 
 | Property | Type | Default | Description |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `servers` | Hash | `{ 'pool.ntp.org' => 'iburst' }` | NTP servers to configure, keyed by hostname with option strings as values. |
 | `pools` | Hash | `{}` | NTP pools to configure, keyed by hostname with option strings as values. |
 | `allow` | Array | `[]` | Networks or hosts allowed to query the local chrony server. |

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -85,6 +85,8 @@ suites:
       inspec_tests:
         - path: test/integration/default
   - name: server
+    provisioner:
+      named_run_list: server
     run_list:
       - recipe[test::server]
     verifier:

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -37,11 +37,6 @@ platforms:
       image: dokken/debian-12
       pid_one_command: /bin/systemd
 
-  - name: debian-13
-    driver:
-      image: dokken/debian-13
-      pid_one_command: /bin/systemd
-
   - name: fedora-latest
     driver:
       image: dokken/fedora-latest

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -1,6 +1,8 @@
 driver:
   name: dokken
   privileged: true
+  cap_add:
+    - SYS_TIME
   chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
 
 transport: { name: dokken }

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -35,6 +35,8 @@ suites:
       inspec_tests:
         - path: test/integration/default
   - name: server
+    provisioner:
+      named_run_list: server
     run_list:
       - recipe[test::server]
     verifier:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -18,7 +18,6 @@ platforms:
   - name: centos-stream-9
   - name: centos-stream-10
   - name: debian-12
-  - name: debian-13
   - name: fedora-latest
   - name: oraclelinux-9
   - name: oraclelinux-10

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -44,15 +44,19 @@ module Chrony
       end
 
       def chrony_conf_group
-        rhel_family_10_or_later? ? chrony_user : 'root'
+        chrony_reads_config_as_service_user? ? chrony_user : 'root'
       end
 
       def chrony_conf_mode
-        rhel_family_10_or_later? ? '0640' : '0600'
+        chrony_reads_config_as_service_user? ? '0640' : '0600'
       end
 
       def rhel_family_10_or_later?
         platform_family?('rhel') && node['platform_version'].to_i >= 10
+      end
+
+      def chrony_reads_config_as_service_user?
+        rhel_family_10_or_later? || platform_family?('amazon')
       end
     end
   end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -38,6 +38,10 @@ module Chrony
           '/etc/chrony/chrony.conf'
         end
       end
+
+      def chrony_user
+        platform_family?('debian') ? '_chrony' : 'chrony'
+      end
     end
   end
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -42,6 +42,18 @@ module Chrony
       def chrony_user
         platform_family?('debian') ? '_chrony' : 'chrony'
       end
+
+      def chrony_conf_group
+        rhel_family_10_or_later? ? chrony_user : 'root'
+      end
+
+      def chrony_conf_mode
+        rhel_family_10_or_later? ? '0640' : '0600'
+      end
+
+      def rhel_family_10_or_later?
+        platform_family?('rhel') && node['platform_version'].to_i >= 10
+      end
     end
   end
 end

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -59,6 +59,14 @@ action :create do
     notifies :restart, "service[#{chrony_service_name}]", :delayed
   end
 
+  directory '/run/chrony.d' do
+    only_if { platform_family?('amazon') }
+  end
+
+  file '/run/chrony.d/.configured' do
+    only_if { platform_family?('amazon') }
+  end
+
   service chrony_service_name do
     supports restart: true, status: true, reload: true
     action [:enable, :start]

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -28,6 +28,7 @@ property :driftfile, String, default: lazy {
   platform_family?('rhel', 'fedora', 'amazon') ? '/var/lib/chrony/drift' : '/var/lib/chrony/chrony.drift'
 }
 property :log_dir, String, default: '/var/log/chrony'
+property :rtcsync, [true, false], default: true
 property :extra_config, Array, default: []
 
 action :create do
@@ -54,6 +55,7 @@ action :create do
       deny: new_resource.deny,
       driftfile: new_resource.driftfile,
       log_dir: new_resource.log_dir,
+      rtcsync: new_resource.rtcsync,
       extra_config: new_resource.extra_config
     )
     notifies :restart, "service[#{chrony_service_name}]", :delayed

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -33,6 +33,13 @@ property :extra_config, Array, default: []
 action :create do
   package 'chrony'
 
+  directory new_resource.log_dir do
+    owner chrony_user
+    group chrony_user
+    mode '0755'
+    recursive true
+  end
+
   template chrony_conf_file do
     source 'chrony.conf.erb'
     cookbook 'chrony'

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -45,8 +45,8 @@ action :create do
     source 'chrony.conf.erb'
     cookbook 'chrony'
     owner 'root'
-    group 'root'
-    mode '0600'
+    group chrony_conf_group
+    mode chrony_conf_mode
     variables(
       servers: new_resource.servers,
       pools: new_resource.pools,

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -28,7 +28,6 @@ property :driftfile, String, default: lazy {
   platform_family?('rhel', 'fedora', 'amazon') ? '/var/lib/chrony/drift' : '/var/lib/chrony/chrony.drift'
 }
 property :log_dir, String, default: '/var/log/chrony'
-property :rtcsync, [true, false], default: true
 property :extra_config, Array, default: []
 
 action :create do
@@ -55,7 +54,6 @@ action :create do
       deny: new_resource.deny,
       driftfile: new_resource.driftfile,
       log_dir: new_resource.log_dir,
-      rtcsync: new_resource.rtcsync,
       extra_config: new_resource.extra_config
     )
     notifies :restart, "service[#{chrony_service_name}]", :delayed

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -38,6 +38,7 @@ action :create do
     group chrony_user
     mode '0755'
     recursive true
+    not_if { ::Dir.exist?(new_resource.log_dir) }
   end
 
   template chrony_conf_file do

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -9,8 +9,8 @@ shared_examples 'chrony_config :create' do
     expect(chef_run).to create_template(conf_file)
       .with(
         owner: 'root',
-        group: 'root',
-        mode: '0600'
+        group: conf_group,
+        mode: conf_mode
       )
   end
 

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -15,12 +15,12 @@ shared_examples 'chrony_config :create' do
   end
 
   it 'creates the chrony log directory' do
-    expect(chef_run).to create_directory('/var/log/chrony')
-      .with(
-        owner: chrony_user,
-        group: chrony_user,
-        mode: '0755'
-      )
+    log_dir = chef_run.find_resource(:directory, '/var/log/chrony')
+
+    expect(log_dir.owner).to eq(chrony_user)
+    expect(log_dir.group).to eq(chrony_user)
+    expect(log_dir.mode).to eq('0755')
+    expect(log_dir.recursive).to be true
   end
 
   it 'enables the chrony service' do

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -14,6 +14,15 @@ shared_examples 'chrony_config :create' do
       )
   end
 
+  it 'creates the chrony log directory' do
+    expect(chef_run).to create_directory('/var/log/chrony')
+      .with(
+        owner: chrony_user,
+        group: chrony_user,
+        mode: '0755'
+      )
+  end
+
   it 'enables the chrony service' do
     expect(chef_run).to enable_service(service_name)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 require_relative 'shared_examples'
 
 RSpec.configure do |config|

--- a/spec/unit/resources/config_spec.rb
+++ b/spec/unit/resources/config_spec.rb
@@ -14,6 +14,8 @@ describe 'chrony_config' do
       end
 
       let(:conf_file) { '/etc/chrony.conf' }
+      let(:conf_group) { 'root' }
+      let(:conf_mode) { '0600' }
       let(:service_name) { 'chronyd' }
       let(:chrony_user) { 'chrony' }
 
@@ -40,6 +42,23 @@ describe 'chrony_config' do
       end
     end
 
+    context 'on AlmaLinux 10 (RHEL family)' do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(
+          platform: 'almalinux', version: '10',
+          step_into: ['chrony_config']
+        ).converge('test::default')
+      end
+
+      let(:conf_file) { '/etc/chrony.conf' }
+      let(:conf_group) { 'chrony' }
+      let(:conf_mode) { '0640' }
+      let(:service_name) { 'chronyd' }
+      let(:chrony_user) { 'chrony' }
+
+      include_examples 'chrony_config :create'
+    end
+
     context 'on Ubuntu 24.04 (Debian family)' do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(
@@ -49,6 +68,8 @@ describe 'chrony_config' do
       end
 
       let(:conf_file) { '/etc/chrony/chrony.conf' }
+      let(:conf_group) { 'root' }
+      let(:conf_mode) { '0600' }
       let(:service_name) { 'chrony' }
       let(:chrony_user) { '_chrony' }
 

--- a/spec/unit/resources/config_spec.rb
+++ b/spec/unit/resources/config_spec.rb
@@ -15,6 +15,7 @@ describe 'chrony_config' do
 
       let(:conf_file) { '/etc/chrony.conf' }
       let(:service_name) { 'chronyd' }
+      let(:chrony_user) { 'chrony' }
 
       include_examples 'chrony_config :create'
 
@@ -49,6 +50,7 @@ describe 'chrony_config' do
 
       let(:conf_file) { '/etc/chrony/chrony.conf' }
       let(:service_name) { 'chrony' }
+      let(:chrony_user) { '_chrony' }
 
       include_examples 'chrony_config :create'
 

--- a/spec/unit/resources/config_spec.rb
+++ b/spec/unit/resources/config_spec.rb
@@ -40,11 +40,6 @@ describe 'chrony_config' do
         expect(chef_run).to render_file('/etc/chrony.conf')
           .with_content(/^log measurements statistics tracking$/)
       end
-
-      it 'enables kernel RTC sync by default' do
-        expect(chef_run).to render_file('/etc/chrony.conf')
-          .with_content(/^rtcsync$/)
-      end
     end
 
     context 'on AlmaLinux 10 (RHEL family)' do
@@ -62,11 +57,6 @@ describe 'chrony_config' do
       let(:chrony_user) { 'chrony' }
 
       include_examples 'chrony_config :create'
-
-      it 'can disable kernel RTC sync for containerized -x tests' do
-        expect(chef_run).not_to render_file('/etc/chrony.conf')
-          .with_content(/^rtcsync$/)
-      end
     end
 
     context 'on Ubuntu 24.04 (Debian family)' do

--- a/spec/unit/resources/config_spec.rb
+++ b/spec/unit/resources/config_spec.rb
@@ -40,6 +40,11 @@ describe 'chrony_config' do
         expect(chef_run).to render_file('/etc/chrony.conf')
           .with_content(/^log measurements statistics tracking$/)
       end
+
+      it 'enables kernel RTC sync by default' do
+        expect(chef_run).to render_file('/etc/chrony.conf')
+          .with_content(/^rtcsync$/)
+      end
     end
 
     context 'on AlmaLinux 10 (RHEL family)' do
@@ -57,6 +62,11 @@ describe 'chrony_config' do
       let(:chrony_user) { 'chrony' }
 
       include_examples 'chrony_config :create'
+
+      it 'can disable kernel RTC sync for containerized -x tests' do
+        expect(chef_run).not_to render_file('/etc/chrony.conf')
+          .with_content(/^rtcsync$/)
+      end
     end
 
     context 'on Ubuntu 24.04 (Debian family)' do

--- a/templates/chrony.conf.erb
+++ b/templates/chrony.conf.erb
@@ -28,5 +28,7 @@ deny <%= deny %>
 # if its offset is larger than 1 second.
 makestep 1.0 3
 
+<% if @rtcsync -%>
 # Enable kernel synchronization of the real-time clock (RTC).
 rtcsync
+<% end -%>

--- a/templates/chrony.conf.erb
+++ b/templates/chrony.conf.erb
@@ -28,7 +28,5 @@ deny <%= deny %>
 # if its offset is larger than 1 second.
 makestep 1.0 3
 
-<% if @rtcsync -%>
 # Enable kernel synchronization of the real-time clock (RTC).
 rtcsync
-<% end -%>

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -13,7 +13,20 @@ if (platform_family?('rhel') && node['platform_version'].to_i >= 10) || platform
   end
 end
 
+if platform_family?('rhel') && node['platform_version'].to_i >= 10
+  execute 'systemctl daemon-reload' do
+    action :nothing
+  end
+
+  systemd_unit 'chronyd.service.d/kitchen.conf' do
+    content <<~UNIT
+      [Service]
+      Type=simple
+    UNIT
+    notifies :run, 'execute[systemctl daemon-reload]', :immediately
+  end
+end
+
 chrony_config 'default' do
-  rtcsync false if (platform_family?('rhel') && node['platform_version'].to_i >= 10) || platform_family?('amazon')
   extra_config ['log measurements statistics tracking']
 end

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -14,5 +14,6 @@ if (platform_family?('rhel') && node['platform_version'].to_i >= 10) || platform
 end
 
 chrony_config 'default' do
+  rtcsync false if (platform_family?('rhel') && node['platform_version'].to_i >= 10) || platform_family?('amazon')
   extra_config ['log measurements statistics tracking']
 end

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -2,14 +2,6 @@
 
 apt_update
 
-directory '/var/run/chrony' do
-  owner 'chrony'
-  group 'chrony'
-  mode '0755'
-  recursive true
-  only_if { platform_family?('rhel', 'fedora', 'amazon') }
-end
-
 chrony_config 'default' do
   extra_config ['log measurements statistics tracking']
 end

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -2,7 +2,13 @@
 
 apt_update
 
-directory '/var/run/chrony' if platform_family?('rhel', 'fedora', 'amazon')
+directory '/var/run/chrony' do
+  owner 'chrony'
+  group 'chrony'
+  mode '0755'
+  recursive true
+  only_if { platform_family?('rhel', 'fedora', 'amazon') }
+end
 
 chrony_config 'default' do
   extra_config ['log measurements statistics tracking']

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -23,6 +23,7 @@ if platform_family?('rhel') && node['platform_version'].to_i >= 10
       [Service]
       Type=simple
     UNIT
+    action :create
     notifies :run, 'execute[systemctl daemon-reload]', :immediately
   end
 end

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -18,6 +18,8 @@ if platform_family?('rhel') && node['platform_version'].to_i >= 10
     action :nothing
   end
 
+  directory '/etc/systemd/system/chronyd.service.d'
+
   systemd_unit 'chronyd.service.d/kitchen.conf' do
     content <<~UNIT
       [Service]

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -2,7 +2,7 @@
 
 apt_update
 
-if platform_family?('rhel') && node['platform_version'].to_i >= 10
+if (platform_family?('rhel') && node['platform_version'].to_i >= 10) || platform_family?('amazon')
   package 'chrony'
 
   file '/etc/sysconfig/chronyd' do

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -6,7 +6,7 @@ if platform_family?('rhel') && node['platform_version'].to_i >= 10
   package 'chrony'
 
   file '/etc/sysconfig/chronyd' do
-    content %(# Command-line options for chronyd\nOPTIONS="-F 0"\n)
+    content %(# Command-line options for chronyd\nOPTIONS="-x -F 0"\n)
     owner 'root'
     group 'root'
     mode '0644'

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -25,6 +25,7 @@ if platform_family?('rhel') && node['platform_version'].to_i >= 10
       [Service]
       Type=simple
     UNIT
+    verify false
     action :create
     notifies :run, 'execute[systemctl daemon-reload]', :immediately
   end

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -2,6 +2,17 @@
 
 apt_update
 
+if platform_family?('rhel') && node['platform_version'].to_i >= 10
+  package 'chrony'
+
+  file '/etc/sysconfig/chronyd' do
+    content %(# Command-line options for chronyd\nOPTIONS="-F 0"\n)
+    owner 'root'
+    group 'root'
+    mode '0644'
+  end
+end
+
 chrony_config 'default' do
   extra_config ['log measurements statistics tracking']
 end

--- a/test/cookbooks/test/recipes/server.rb
+++ b/test/cookbooks/test/recipes/server.rb
@@ -2,14 +2,6 @@
 
 apt_update
 
-directory '/var/run/chrony' do
-  owner 'chrony'
-  group 'chrony'
-  mode '0755'
-  recursive true
-  only_if { platform_family?('rhel', 'fedora', 'amazon') }
-end
-
 chrony_config 'server' do
   allow ['10.0.0.0/8']
 end

--- a/test/cookbooks/test/recipes/server.rb
+++ b/test/cookbooks/test/recipes/server.rb
@@ -13,7 +13,20 @@ if (platform_family?('rhel') && node['platform_version'].to_i >= 10) || platform
   end
 end
 
+if platform_family?('rhel') && node['platform_version'].to_i >= 10
+  execute 'systemctl daemon-reload' do
+    action :nothing
+  end
+
+  systemd_unit 'chronyd.service.d/kitchen.conf' do
+    content <<~UNIT
+      [Service]
+      Type=simple
+    UNIT
+    notifies :run, 'execute[systemctl daemon-reload]', :immediately
+  end
+end
+
 chrony_config 'server' do
-  rtcsync false if (platform_family?('rhel') && node['platform_version'].to_i >= 10) || platform_family?('amazon')
   allow ['10.0.0.0/8']
 end

--- a/test/cookbooks/test/recipes/server.rb
+++ b/test/cookbooks/test/recipes/server.rb
@@ -2,7 +2,13 @@
 
 apt_update
 
-directory '/var/run/chrony' if platform_family?('rhel', 'fedora', 'amazon')
+directory '/var/run/chrony' do
+  owner 'chrony'
+  group 'chrony'
+  mode '0755'
+  recursive true
+  only_if { platform_family?('rhel', 'fedora', 'amazon') }
+end
 
 chrony_config 'server' do
   allow ['10.0.0.0/8']

--- a/test/cookbooks/test/recipes/server.rb
+++ b/test/cookbooks/test/recipes/server.rb
@@ -23,6 +23,7 @@ if platform_family?('rhel') && node['platform_version'].to_i >= 10
       [Service]
       Type=simple
     UNIT
+    action :create
     notifies :run, 'execute[systemctl daemon-reload]', :immediately
   end
 end

--- a/test/cookbooks/test/recipes/server.rb
+++ b/test/cookbooks/test/recipes/server.rb
@@ -18,6 +18,8 @@ if platform_family?('rhel') && node['platform_version'].to_i >= 10
     action :nothing
   end
 
+  directory '/etc/systemd/system/chronyd.service.d'
+
   systemd_unit 'chronyd.service.d/kitchen.conf' do
     content <<~UNIT
       [Service]

--- a/test/cookbooks/test/recipes/server.rb
+++ b/test/cookbooks/test/recipes/server.rb
@@ -14,5 +14,6 @@ if (platform_family?('rhel') && node['platform_version'].to_i >= 10) || platform
 end
 
 chrony_config 'server' do
+  rtcsync false if (platform_family?('rhel') && node['platform_version'].to_i >= 10) || platform_family?('amazon')
   allow ['10.0.0.0/8']
 end

--- a/test/cookbooks/test/recipes/server.rb
+++ b/test/cookbooks/test/recipes/server.rb
@@ -2,7 +2,7 @@
 
 apt_update
 
-if platform_family?('rhel') && node['platform_version'].to_i >= 10
+if (platform_family?('rhel') && node['platform_version'].to_i >= 10) || platform_family?('amazon')
   package 'chrony'
 
   file '/etc/sysconfig/chronyd' do

--- a/test/cookbooks/test/recipes/server.rb
+++ b/test/cookbooks/test/recipes/server.rb
@@ -6,7 +6,7 @@ if platform_family?('rhel') && node['platform_version'].to_i >= 10
   package 'chrony'
 
   file '/etc/sysconfig/chronyd' do
-    content %(# Command-line options for chronyd\nOPTIONS="-F 0"\n)
+    content %(# Command-line options for chronyd\nOPTIONS="-x -F 0"\n)
     owner 'root'
     group 'root'
     mode '0644'

--- a/test/cookbooks/test/recipes/server.rb
+++ b/test/cookbooks/test/recipes/server.rb
@@ -25,6 +25,7 @@ if platform_family?('rhel') && node['platform_version'].to_i >= 10
       [Service]
       Type=simple
     UNIT
+    verify false
     action :create
     notifies :run, 'execute[systemctl daemon-reload]', :immediately
   end

--- a/test/cookbooks/test/recipes/server.rb
+++ b/test/cookbooks/test/recipes/server.rb
@@ -2,6 +2,17 @@
 
 apt_update
 
+if platform_family?('rhel') && node['platform_version'].to_i >= 10
+  package 'chrony'
+
+  file '/etc/sysconfig/chronyd' do
+    content %(# Command-line options for chronyd\nOPTIONS="-F 0"\n)
+    owner 'root'
+    group 'root'
+    mode '0644'
+  end
+end
+
 chrony_config 'server' do
   allow ['10.0.0.0/8']
 end

--- a/test/integration/default/controls/default.rb
+++ b/test/integration/default/controls/default.rb
@@ -10,8 +10,8 @@ chrony_service = if os.redhat? || os.name == 'fedora'
                    'chrony'
                  end
 
-chrony_conf_group = os.redhat? && os.release.to_i >= 10 ? 'chrony' : 'root'
-chrony_conf_mode = os.redhat? && os.release.to_i >= 10 ? '0640' : '0600'
+chrony_conf_group = (os.redhat? && os.release.to_i >= 10) || os.name == 'amazon' ? 'chrony' : 'root'
+chrony_conf_mode = (os.redhat? && os.release.to_i >= 10) || os.name == 'amazon' ? '0640' : '0600'
 
 control 'chrony-client-01' do
   impact 1.0

--- a/test/integration/default/controls/default.rb
+++ b/test/integration/default/controls/default.rb
@@ -10,6 +10,9 @@ chrony_service = if os.redhat? || os.name == 'fedora'
                    'chrony'
                  end
 
+chrony_conf_group = os.redhat? && os.release.to_i >= 10 ? 'chrony' : 'root'
+chrony_conf_mode = os.redhat? && os.release.to_i >= 10 ? '0640' : '0600'
+
 control 'chrony-client-01' do
   impact 1.0
   title 'chrony package is installed'
@@ -39,8 +42,8 @@ control 'chrony-client-03' do
   describe file(chrony_conf_file) do
     it { should be_file }
     its('owner') { should eq 'root' }
-    its('group') { should eq 'root' }
-    its('mode') { should cmp '0600' }
+    its('group') { should eq chrony_conf_group }
+    its('mode') { should cmp chrony_conf_mode }
     its('content') { should match(/^server pool\.ntp\.org iburst/) }
     its('content') { should match(/^driftfile /) }
     its('content') { should match(/^log measurements statistics tracking$/) }

--- a/test/integration/server/controls/default.rb
+++ b/test/integration/server/controls/default.rb
@@ -10,6 +10,9 @@ chrony_service = if os.redhat? || os.name == 'fedora'
                    'chrony'
                  end
 
+chrony_conf_group = os.redhat? && os.release.to_i >= 10 ? 'chrony' : 'root'
+chrony_conf_mode = os.redhat? && os.release.to_i >= 10 ? '0640' : '0600'
+
 control 'chrony-server-01' do
   impact 1.0
   title 'chrony package is installed'
@@ -39,8 +42,8 @@ control 'chrony-server-03' do
   describe file(chrony_conf_file) do
     it { should be_file }
     its('owner') { should eq 'root' }
-    its('group') { should eq 'root' }
-    its('mode') { should cmp '0600' }
+    its('group') { should eq chrony_conf_group }
+    its('mode') { should cmp chrony_conf_mode }
     its('content') { should match(/^driftfile /) }
     its('content') { should match(%r{^allow 10\.0\.0\.0/8}) }
   end

--- a/test/integration/server/controls/default.rb
+++ b/test/integration/server/controls/default.rb
@@ -10,8 +10,8 @@ chrony_service = if os.redhat? || os.name == 'fedora'
                    'chrony'
                  end
 
-chrony_conf_group = os.redhat? && os.release.to_i >= 10 ? 'chrony' : 'root'
-chrony_conf_mode = os.redhat? && os.release.to_i >= 10 ? '0640' : '0600'
+chrony_conf_group = (os.redhat? && os.release.to_i >= 10) || os.name == 'amazon' ? 'chrony' : 'root'
+chrony_conf_mode = (os.redhat? && os.release.to_i >= 10) || os.name == 'amazon' ? '0640' : '0600'
 
 control 'chrony-server-01' do
   impact 1.0


### PR DESCRIPTION
## Summary
- migrate dependency resolution from Berksfile to Policyfile
- update ChefSpec setup to use Policyfile resolution
- update Copilot setup to install Chef Workstation 8.0.4 and run chef install Policyfile.rb
- move cookbook limitations into AGENTS.md where present

## Verification
- chef install Policyfile.rb
- cookstyle
- kitchen list
- /opt/chef-workstation/embedded/bin/rspec --format progress